### PR TITLE
Fix: wrong homepage url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         ],
     scripts = [
         ],
-    url = "https://github.com/wnyc/pyzopfli",
+    url = "https://github.com/wnyc/py-zopfli",
     install_requires = [
         ]
 )


### PR DESCRIPTION
https://github.com/wnyc/py-zopfli/issues/4
